### PR TITLE
Added max_lifetime psycopg pool parameter to examples and tests

### DIFF
--- a/examples/psycopg/src/example_with_connection_pool.py
+++ b/examples/psycopg/src/example_with_connection_pool.py
@@ -32,6 +32,7 @@ def connect_with_pool(cluster_user, cluster_endpoint, region):
         kwargs=conn_params,  # Pass params as kwargs
         min_size=2,
         max_size=8,
+        max_lifetime=3300
     )
 
     # Use the pool as a context manager

--- a/examples/psycopg/src/example_with_connection_pool_async.py
+++ b/examples/psycopg/src/example_with_connection_pool_async.py
@@ -32,6 +32,7 @@ async def connect_with_pool(cluster_user, cluster_endpoint, region):
         kwargs=conn_params,  # Pass params as kwargs
         min_size=2,
         max_size=10,
+        max_lifetime=3300,
     ) as pool:
 
         async with pool.connection() as conn:

--- a/examples/psycopg/src/example_with_connection_pool_concurrent.py
+++ b/examples/psycopg/src/example_with_connection_pool_concurrent.py
@@ -33,6 +33,7 @@ def connect_with_pool_concurrent_connections(cluster_user, cluster_endpoint, reg
         kwargs=conn_params,  # Pass params as kwargs
         min_size=2,
         max_size=8,
+        max_lifetime=3300,
         open=True,
     )
 

--- a/tests/integration/test_integration_psycopg_pool.py
+++ b/tests/integration/test_integration_psycopg_pool.py
@@ -51,6 +51,7 @@ class TestIntegrationPool:
             kwargs=cluster_config,  # Pass IAM params as kwargs
             min_size=2,
             max_size=8,
+            max_lifetime=3300,
         )
 
         with pool as p:


### PR DESCRIPTION
*Description of changes:*
Added max_lifetime psycopg pool parameter to examples and tests

The max_lifetime parameter should be set to less than 3600 seconds (one hour), as this is the maximum connection duration allowed by Aurora DSQL database. Setting a lower max_lifetime allows the connection pool to proactively manage connection recycling, which is more efficient than handling connection timeout errors from the database.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
